### PR TITLE
READMEs now decoded to markdown

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -75,10 +75,15 @@ func main() {
 		//owner := *rp.Owner.Login
 
 		if strings.Contains(repo, keyword) {
-			readme, _, err := client.Repositories.GetReadme(org, repo, &github.RepositoryContentGetOptions{})
+			encodedText, _, err := client.Repositories.GetReadme(org, repo, &github.RepositoryContentGetOptions{})
 			if err != nil {
 				log.Printf("Repositories.GetReadme returned error: %v", err)
 			}
+			text, err := encodedText.Decode()
+			if err != nil {
+				log.Printf("Decoding failed: %v", err)
+			}
+			readme := string(text)
 			fmt.Printf("Found a readme for %v", readme)
 			// look up each repo and say if you find a README
 		}


### PR DESCRIPTION
- text requires decoding and now works.
- Clarified variables

Now that I understand the returned object is base64 encoded and not the README itself, I renamed the variables to match. This was surprisingly confusing to me, but thank goodness for friends.
